### PR TITLE
Use exact 3.0.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ace-css": "^1.0.1",
     "css-loader": "^0.23.1",
-    "elm-webpack-loader": "^3.0.1",
+    "elm-webpack-loader": "3.0.1",
     "file-loader": "^0.8.5",
     "font-awesome": "^4.6.1",
     "json-server": "^0.8.14",


### PR DESCRIPTION
3.0.4 (latest [official github release](https://github.com/rtfeldman/elm-webpack-loader/releases) for `elm-wepack-loader`) was not working for me. It was failing my builds from a fresh clone with...

```
npm run dev

> elm-tutorial-app@1.0.0 dev /Users/blakewest/code/elm-tutorial-app
> webpack-dev-server --port 3000

ERROR in ./src/Main.elm
Module build failed: TypeError: undefined is not a function
    at Object.getOptions (/Users/blakewest/code/elm-tutorial-app/node_modules/elm-webpack-loader/index.js:20:17)
    at Object.module.exports (/Users/blakewest/code/elm-tutorial-app/node_modules/elm-webpack-loader/index.js:40:28)
 @ ./src/index.js 9:10-31
```

Moving to 3.0.1 exactly solved the problem. Not sure exactly what's up with webpack loader, but figure it's better to keep the tutorial thing actually working. It's not a great experience to have the tutorial app fail to build when trying to learn elm! 

Also.... the deps should be fixed in the actual tutorial too!: http://www.elm-tutorial.org/en/04-starting/03-webpack.html

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sporto/elm-tutorial-app/14)

<!-- Reviewable:end -->
