### PR TITLE
Decode string player-id from server to int Player model. Fix for issue #20

### DIFF
--- a/src/Players/Commands.elm
+++ b/src/Players/Commands.elm
@@ -21,7 +21,7 @@ fetchAllUrl =
 
 saveUrl : PlayerId -> String
 saveUrl playerId =
-    "http://localhost:4000/players/" ++ playerId
+    "http://localhost:4000/players/" ++ (toString playerId)
 
 
 saveRequest : Player -> Http.Request Player
@@ -54,17 +54,21 @@ collectionDecoder =
 
 memberDecoder : Decode.Decoder Player
 memberDecoder =
-    Decode.map3 Player
-        (field "id" Decode.string)
-        (field "name" Decode.string)
-        (field "level" Decode.int)
+    let
+        stringToIntDecoder =
+            Decode.map (\s -> Result.withDefault 0 (String.toInt s)) Decode.string
+    in
+        Decode.map3 Player
+            (field "id" stringToIntDecoder)
+            (field "name" Decode.string)
+            (field "level" Decode.int)
 
 
 memberEncoded : Player -> Encode.Value
 memberEncoded player =
     let
         list =
-            [ ( "id", Encode.string player.id )
+            [ ( "id", Encode.int player.id )
             , ( "name", Encode.string player.name )
             , ( "level", Encode.int player.level )
             ]

--- a/src/Players/List.elm
+++ b/src/Players/List.elm
@@ -41,7 +41,7 @@ list players =
 playerRow : Player -> Html Msg
 playerRow player =
     tr []
-        [ td [] [ text player.id ]
+        [ td [] [ text (toString player.id) ]
         , td [] [ text player.name ]
         , td [] [ text (toString player.level) ]
         , td []

--- a/src/Players/Models.elm
+++ b/src/Players/Models.elm
@@ -2,7 +2,7 @@ module Players.Models exposing (..)
 
 
 type alias PlayerId =
-    String
+    Int
 
 
 type alias Player =
@@ -14,7 +14,7 @@ type alias Player =
 
 new : Player
 new =
-    { id = "0"
+    { id = 0
     , name = ""
     , level = 1
     }

--- a/src/Players/Update.elm
+++ b/src/Players/Update.elm
@@ -43,7 +43,7 @@ update message players =
             ( players, Navigation.newUrl "#players" )
 
         ShowPlayer id ->
-            ( players, Navigation.newUrl ("#players/" ++ id) )
+            ( players, Navigation.newUrl ("#players/" ++ (toString id)) )
 
         ChangeLevel id howMuch ->
             ( players, changeLevelCommands id howMuch players |> Cmd.batch )

--- a/src/Routing.elm
+++ b/src/Routing.elm
@@ -15,7 +15,7 @@ matchers : Parser (Route -> a) a
 matchers =
     oneOf
         [ map PlayersRoute top
-        , map PlayerRoute (s "players" </> string)
+        , map PlayerRoute (s "players" </> int)
         , map PlayersRoute (s "players")
         ]
 


### PR DESCRIPTION
I think it's pretty common to massage server data in different ways. This commit shows a simple way to decode string to int